### PR TITLE
Fixes the column position when invoking idetools.

### DIFF
--- a/autoload/nimrod.vim
+++ b/autoload/nimrod.vim
@@ -62,7 +62,7 @@ let g:nimrod_symbol_types = {
 
 fun! NimExec(op)
   let cmd = printf("nimrod idetools %s --track:\"%s,%d,%d\" \"%s\"",
-            \ a:op, expand('%:p'), line('.'), col('.'), CurrentNimrodFile())
+            \ a:op, expand('%:p'), line('.'), col('.')-1, CurrentNimrodFile())
 
   call add(g:nim_log, cmd)
   let output = system(cmd)


### PR DESCRIPTION
Vim starts counting columns from 1 but the nimrod idetools command
starts from zero. This can be verified writing a call to the quit() proc
with a two level identation and trying to invoke idetools on the
whitespace before the word.
