### PR TITLE
Disables silence when invoking idetools. Refs #4.

### DIFF
--- a/autoload/nimrod.vim
+++ b/autoload/nimrod.vim
@@ -114,7 +114,7 @@ fun! GotoDefinition_nimrod()
   let defBits = split(rawDef, '\t')
   let file = defBits[4]
   let line = defBits[5]
-  exe printf("silent! e +%d %s", line, file)
+  exe printf("e +%d %s", line, file)
   return 1
 endf
 


### PR DESCRIPTION
After some time editing with the "silent!" bit removed everything seems
to work fine, so maybe the silencing was done when there was no error
log.
