### PR TITLE
Disables hints for check command.

### DIFF
--- a/autoload/nimrod.vim
+++ b/autoload/nimrod.vim
@@ -202,7 +202,7 @@ endf
 
 " Syntastic syntax checking
 fun! SyntaxCheckers_nimrod_nimrod_GetLocList()
-  let makeprg = 'nimrod check ' . s:CurrentNimrodFile()
+  let makeprg = 'nimrod check --hints:off ' . s:CurrentNimrodFile()
   let errorformat = &errorformat
   
   return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })


### PR DESCRIPTION
Paths for babel packages being reported by the compiler are considered
errors and interfere with syntastic's :lnext and :lprevious support.
