### PR TITLE
look for either 'nimrod' or 'nim' as the compiler

### DIFF
--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -5,7 +5,7 @@ if !exists("g:nim_caas_enabled")
   let g:nim_caas_enabled = 1
 endif
 
-if !executable('nim')
+if !executable('nimrod') && !executable('nim')
   echoerr "the Nim compiler must be in your system's PATH"
 endif
 


### PR DESCRIPTION
I just installed 0.9.6 of nim from source, then installed the plugin via Vundle. After opening a .nim file, vim was complaining about not finding the compiler in the path. On line 9 of the `autoload/nim.vim` script it was only looking for a binary named `nim` in the path. I updated it to find either `nimrod` or `nim` in the path and it's now working.

I'm new to Nim but it appears the old binary was `nim`? Or maybe that's the new name? Either way 0.9.6 when built as per the website produces a binary named `nimrod`, so the plugin now looks for it.
