### PR TITLE
nim_vim.py should use platform independent temporary files directory for the log

### DIFF
--- a/autoload/nim_vim.py
+++ b/autoload/nim_vim.py
@@ -75,7 +75,7 @@ def nimRestartService(project):
   nimTerminateService(project)
   nimStartService(project)
 
-NimLog = open(''.join([tempfile.gettempdir(), "nim-log.txt"]), "w")
+NimLog = open(os.path.join(tempfile.gettempdir(), "nim-log.txt"), "w")
 
 def nimExecCmd(project, cmd, async = True):
   target = None

--- a/autoload/nim_vim.py
+++ b/autoload/nim_vim.py
@@ -1,4 +1,4 @@
-import threading, Queue, subprocess, signal, os
+import threading, Queue, subprocess, signal, os, tempfile
 
 try:
   import vim
@@ -75,7 +75,7 @@ def nimRestartService(project):
   nimTerminateService(project)
   nimStartService(project)
 
-NimLog = open("/tmp/nim-log.txt", "w")
+NimLog = open(''.join([tempfile.gettempdir(), "nim-log.txt"]), "w")
 
 def nimExecCmd(project, cmd, async = True):
   target = None


### PR DESCRIPTION
Hi,

This PR changes nim_vim.py NimLog to have a valid location on all platforms. Please let me know if there are any changes you would like me to make! Thanks!