### PR TITLE
Added nimBuiltin line for special parameter types

### DIFF
--- a/syntax/nim.vim
+++ b/syntax/nim.vim
@@ -92,6 +92,7 @@ if nim_highlight_builtins == 1
   " builtin functions, types and objects, not really part of the syntax
   syn keyword nimBuiltin int int8 int16 int32 int64 uint uint8 uint16 uint32 uint64 float float32 float64 bool
   syn keyword nimBuiltin char string cstring pointer range array openarray seq
+  syn keyword nimBuiltin typedesc varargs typed untyped stmt expr
   syn keyword nimBuiltin set Byte Natural Positive Conversion
   syn keyword nimBuiltin BiggestInt BiggestFloat cchar cschar cshort cint csize cuchar cushort
   syn keyword nimBuiltin clong clonglong cfloat cdouble clongdouble cuint culong culonglong cchar


### PR DESCRIPTION
These parameter types are described in the Nim manual sections below.
- [typedesc](http://www.build.nim-lang.org/docs/manual.html#special-types-typedesc)
- [varargs](http://www.build.nim-lang.org/docs/manual.html#types-varargs)
- [typed, untyped, expr, and stmt](http://www.build.nim-lang.org/docs/manual.html#templates-typed-vs-untyped-parameters)

Without this highlighting, certain metaprogramming parameters can be a bit hard to read.
`template example(member: untyped, T: typedesc) =`
