### PR TITLE
replace for python3

### DIFF
--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -9,7 +9,11 @@ if !executable('nim')
   echoerr "the Nim compiler must be in your system's PATH"
 endif
 
-exe 'pyfile ' . fnameescape(s:plugin_path) . '/nim_vim.py'
+if has('python3')
+    exe 'py3file ' . fnameescape(s:plugin_path) . '/nim_vim.py'
+else
+    exe 'pyfile ' . fnameescape(s:plugin_path) . '/nim_vim.py'
+endif
 
 fun! nim#init()
   let cmd = printf("nim --dump.format:json --verbosity:0 dump %s", s:CurrentNimFile())

--- a/autoload/nim_vim.py
+++ b/autoload/nim_vim.py
@@ -1,19 +1,19 @@
-import threading, Queue, subprocess, signal, os, platform, getpass
+import threading, queue, subprocess, signal, os, platform, getpass
 
 try:
   import vim
 except ImportError:
   class Vim:
     def command(self, x):
-      print("Executing vim command: " + x)
+      print(("Executing vim command: " + x))
   
   vim = Vim()
 
 class NimThread(threading.Thread):
   def __init__(self, project_path):
     super(NimThread, self).__init__()
-    self.tasks = Queue.Queue()
-    self.responses = Queue.Queue()
+    self.tasks = queue.Queue()
+    self.responses = queue.Queue()
     self.nim = subprocess.Popen(
        ["nim", "serve", "--server.type:stdin", project_path],
        cwd = os.path.dirname(project_path),
@@ -67,7 +67,7 @@ def nimStartService(project):
   return target
 
 def nimTerminateService(project):
-  if NimProjects.has_key(project):
+  if project in NimProjects:
     NimProjects[project].postNimCmd("quit")
     del NimProjects[project]
 
@@ -77,7 +77,7 @@ def nimRestartService(project):
 
 def nimExecCmd(project, cmd, async = True):
   target = None
-  if NimProjects.has_key(project):
+  if project in NimProjects:
     target = NimProjects[project]
   else:
     target = nimStartService(project)
@@ -88,6 +88,6 @@ def nimExecCmd(project, cmd, async = True):
     vim.command('let l:py_res = "' + nimVimEscape(result) + '"')
 
 def nimTerminateAll():
-  for thread in NimProjects.values():
+  for thread in list(NimProjects.values()):
     thread.postNimCmd("quit")
     

--- a/autoload/simulator.py
+++ b/autoload/simulator.py
@@ -5,13 +5,13 @@ from nimrod_vim import execNimCmd
 proj = "/foo"
 
 while True:
-  line = raw_input("enter command: ")
+  line = eval(input("enter command: "))
   async = False
   
   if line == "quit":
     async = True
   
-  print execNimCmd(proj, line, async)
+  print((execNimCmd(proj, line, async)))
 
   if line == "quit":
     break


### PR DESCRIPTION
using python3 with vim,

```
Error detected while processing ~~~/nim.vim/autoload/nim.vim:
line   12:
E319: Sorry, the command is not available in this version: pyfile ~~~/nim.vim/autoload/nim_vim.py
```
