### PR TITLE
Fix so jumping within dirty buffer works

### DIFF
--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -197,7 +197,13 @@ fun! GotoDefinition_nim_ready(def_output)
   let defBits = split(rawDef, '\t')
   let file = defBits[4]
   let line = defBits[5]
-  exe printf("e +%d %s", line, file)
+
+  if bufloaded(file)   " Not sure we don't want bufexists() here instead
+    exe printf("buffer +%d %s",line, file)
+  else
+    exe printf("e +%d %s", line, file)
+  endif
+
   return 1
 endf
 


### PR DESCRIPTION
Using :e (edit) tries to clobber the changes to the buffer, so vim stops it.  This fixes this problem by using :buffer instead of :edit for open files.  Note that the behavior with respect to dirty buffers is still somewhat half-assed: jumps to other buffers that are also dirty go to the wrong line.  But this is no worse than it was, and to fix it all dirty nim buffers would need to be saved, and that means even greater divergence with what the command-line compiler is going to see, and that might end up being even more confusion-prone the present behavior anyway.