### PR TITLE
Use cursor() to get to correct column

### DIFF
--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -197,7 +197,9 @@ fun! GotoDefinition_nim_ready(def_output)
   let defBits = split(rawDef, '\t')
   let file = defBits[4]
   let line = defBits[5]
+  let column = defBits[6]
   exe printf("e +%d %s", line, file)
+  call cursor(line, column + 1)
   return 1
 endf
 


### PR DESCRIPTION
This can be worth doing to help with jumping to parameters or strangely formatted stuff.  Can be combined with the noclobber pull request I just made in the obvious way