### PR TITLE
Fix numerical syntax

### DIFF
--- a/syntax/nim.vim
+++ b/syntax/nim.vim
@@ -82,10 +82,11 @@ syn match nimEscapeError "\\x\x\=\X" display contained
 
 if nim_highlight_numbers == 1
   " numbers (including longs and complex)
-  syn match   nimNumber	"\v<0x\x+(\'(i|I|f|F|u|U)(8|16|32|64))?>"
-  syn match   nimNumber	"\v<[0-9_]+(\'(i|I|f|F|u|U)(8|16|32|64))?>"
-  syn match   nimNumber	"\v[0-9]\.[0-9_]+([eE][+-]=[0-9_]+)=>"
-  syn match   nimNumber	"\v<[0-9_]+(\.[0-9_]+)?([eE][+-]?[0-9_]+)?(\'(f|F)(32|64))?>"
+  syn match   nimNumber	"\v<0[bB][01]%(_?[01])*%(\'%(%(i|I|u|U)%(8|16|32|64)|u|U|%(f|F)%(32|64|128)?|d|D))?>"
+  syn match   nimNumber	"\v<0[ocC]\o%(_?\o)*%(\'%(%(i|I|u|U)%(8|16|32|64)|u|U|%(f|F)%(32|64|128)?|d|D))?>"
+  syn match   nimNumber	"\v<0[xX]\x%(_?\x)*%(\'%(%(i|I|u|U)%(8|16|32|64)|u|U|%(f|F)%(32|64|128)?|d|D))?>"
+  syn match   nimNumber	"\v<\d%(_?\d)*%(%(\'%(%(i|I|u|U)%(8|16|32|64)|u|U)|%([eE][+-]?\d%(_?\d)*)?\'%(%(%(f|F)%(32|64|128)?|d|D))))?>"
+  syn match   nimNumber	"\v<\d%(_?\d)*\.\d%(_?\d)*%([eE][+-]?\d%(_?\d)*)?%(\'%(%(f|F)%(32|64|128)?|d|D))?>"
 endif
 
 if nim_highlight_builtins == 1


### PR DESCRIPTION
* Fix problem that integer suffix was not highlighted, Because the numeric part matches the floating point pattern defined later(#41, #48).
* Supports binary, octal syntax highlight.
* It corresponds to suffix(`u`, `d`, `f128` etc) which did not correspond.
* Fix highlighted invalid number that beginning is underscore or includes consecutive underscore.
* Fix problem highlighted invalid floating point suffix like `'f8`.
* Change to parentheses that don't capturing groups.