### PR TITLE
Fix numerical syntax

### DIFF
--- a/syntax/nim.vim
+++ b/syntax/nim.vim
@@ -89,7 +89,7 @@ if nim_highlight_numbers == 1
   exe 'syn match nimNumber /\v<0[bB][01]%(_?[01])*%('.s:int_suf.'|'.s:float_suf.')?>/'
   exe 'syn match nimNumber /\v<0[ocC]\o%(_?\o)*%('.s:int_suf.'|'.s:float_suf.')?>/'
   exe 'syn match nimNumber /\v<0[xX]\x%(_?\x)*%('.s:int_suf.'|'.s:float_suf.')?>/'
-  exe 'syn match nimNumber /\v<'.s:dec_num.'%('.s:int_suf.'|'.s:exp.'?'.s:float_suf.')?>/'
+  exe 'syn match nimNumber /\v<'.s:dec_num.'%('.s:int_suf.'|'.s:exp.'?'.s:float_suf.'?)>/'
   exe 'syn match nimNumber /\v<'.s:dec_num.'\.'.s:dec_num.s:exp.'?'.s:float_suf.'?>/'
   unlet s:dec_num s:int_suf s:float_suf s:exp
 endif


### PR DESCRIPTION
@zah Sorry to keep bothering you.

Fix an issue that is not highlighted when floating point suffix is omitted in cases like `1exp+10`.