### PR TITLE
Remove quickrun settings

### DIFF
--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -234,12 +234,3 @@ if exists("g:SyntasticRegistry")
       \ 'filetype': 'nim',
       \ 'name': 'nim'})
 endif
-
-if !exists("g:quickrun_config")
-  let g:quickrun_config = {}
-endif
-
-if !exists("g:quickrun_config.nim")
-  let g:quickrun_config.nim = { "exec": "nim c --run --verbosity:0 %S" }
-endif
-


### PR DESCRIPTION
Now there is a [nim setting](https://github.com/thinca/vim-quickrun/blob/master/autoload/quickrun.vim#L395) in the quick run.  So this code is no longer necessary.
Even if the user has set it with .vimrc, this setting overwrites it. Therefore, I think that this code is not desirable anymore.