### PR TITLE
Include --listfullpaths in makeprg

### DIFF
--- a/compiler/nim.vim
+++ b/compiler/nim.vim
@@ -11,7 +11,7 @@ endif
 let s:cpo_save = &cpo
 set cpo-=C
 
-CompilerSet makeprg=nim\ c\ --verbosity:0\ $*\ %:p
+CompilerSet makeprg=nim\ c\ --verbosity:0\ --listfullpaths\ $*\ %:p
 
 CompilerSet errorformat=
   \%-GHint:\ %m,


### PR DESCRIPTION
Before this change, running `:make` on a file with errors when not
in the same directory as the file would open a buffer in the cwd.
This change fixes this: the compiler outputs the full path to the
file, so a buffer is always opened for the correct file.

`--listfullpaths` was used instead of `--listFullPaths` to be
consistent with `autoload/nim.vim`.