### PR TITLE
Check for python support before queuing autocmd

### DIFF
--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -52,8 +52,10 @@ endf
 augroup NimVim
   au!
   au BufEnter log://nim call s:UpdateNimLog()
-  " au QuitPre * :py nimTerminateAll()
-  au VimLeavePre * :py nimTerminateAll()
+  if has("python3") || has("python")
+    " au QuitPre * :py nimTerminateAll()
+    au VimLeavePre * :py nimTerminateAll()
+  endif
 augroup END
 
 command! NimLog :e log://nim


### PR DESCRIPTION
Versions of Vim compiled without python support will error when attempting to run `:py nimTerminateAll()`, an autocommand for the `VimLeavePre` event. A simple check for python support prevents this.