### PR TITLE
Use pyx or pyxfile (and some fixes with vint)

### DIFF
--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -216,7 +216,7 @@ fun! GotoDefinition_nim() abort
 endf
 
 fun! FindReferences_nim() abort
-  setloclist()
+  "setloclist()
 endf
 
 " Syntastic syntax checking

--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -16,7 +16,7 @@ endif
 fun! nim#init() abort
   let cmd = printf('nim --dump.format:json --verbosity:0 dump %s', s:CurrentNimFile())
   let raw_dumpdata = system(cmd)
-  if !v:shell_error && expand('%:e') == 'nim'
+  if !v:shell_error && expand('%:e') ==# 'nim'
     let false = 0 " Needed for eval of json
     let true = 1 " Needed for eval of json
     let dumpdata = eval(substitute(raw_dumpdata, "\n", '', 'g'))
@@ -26,7 +26,7 @@ fun! nim#init() abort
     let b:nim_caas_enabled = g:nim_caas_enabled || index(dumpdata['defined_symbols'], 'forcecaas') != -1
 
     for path in dumpdata['lib_paths']
-      if finddir(path) == path
+      if finddir(path) ==# path
         let &l:path = path . ',' . &l:path
       endif
     endfor
@@ -134,12 +134,12 @@ fun! NimExecAsync(op, Handler) abort
 endf
 
 fun! NimComplete(findstart, base) abort
-  if b:nim_caas_enabled == 0
+  if b:nim_caas_enabled ==# 0
     return -1
   endif
 
   if a:findstart
-    if synIDattr(synIDtrans(synID(line('.'),col('.'),1)), 'name') == 'Comment'
+    if synIDattr(synIDtrans(synID(line('.'),col('.'),1)), 'name') ==# 'Comment'
       return -1
     endif
     let line = getline('.')
@@ -153,7 +153,7 @@ fun! NimComplete(findstart, base) abort
     let sugOut = NimExec('--suggest')
     for line in split(sugOut, '\n')
       let lineData = split(line, '\t')
-      if len(lineData) > 0 && lineData[0] == 'sug'
+      if len(lineData) > 0 && lineData[0] ==# 'sug'
         let word = split(lineData[2], '\.')[-1]
         if a:base ==? '' || word =~# '^' . a:base
           let kind = get(g:nim_symbol_types, lineData[1], '')

--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -9,10 +9,8 @@ if !executable('nim')
   echoerr "the Nim compiler must be in your system's PATH"
 endif
 
-if has("python3")
-  exe 'py3file ' . fnameescape(s:plugin_path) . '/nim_vim.py'
-elseif has("python")
-  exe 'pyfile ' . fnameescape(s:plugin_path) . '/nim_vim.py'
+if has('pythonx')
+  exe 'pyxfile ' . fnameescape(s:plugin_path) . '/nim_vim.py'
 endif
 
 fun! nim#init()
@@ -54,19 +52,19 @@ endf
 augroup NimVim
   au!
   au BufEnter log://nim call s:UpdateNimLog()
-  if has("python3") || has("python")
-    " au QuitPre * :py nimTerminateAll()
-    au VimLeavePre * :py nimTerminateAll()
+  if has("pythonx")
+    " au QuitPre * :pyx nimTerminateAll()
+    au VimLeavePre * :pyx nimTerminateAll()
   endif
 augroup END
 
 command! NimLog :e log://nim
 
 command! NimTerminateService
-  \ :exe printf("py nimTerminateService('%s')", b:nim_project_root)
+  \ :exe printf("pyx nimTerminateService('%s')", b:nim_project_root)
 
 command! NimRestartService
-  \ :exe printf("py nimRestartService('%s')", b:nim_project_root)
+  \ :exe printf("pyx nimRestartService('%s')", b:nim_project_root)
 
 fun! s:CurrentNimFile()
   let save_cur = getpos('.')
@@ -120,7 +118,7 @@ fun! NimExec(op)
   endif
 
   if b:nim_caas_enabled
-    exe printf("py nimExecCmd('%s', '%s', False)", b:nim_project_root, cmd)
+    exe printf("pyx nimExecCmd('%s', '%s', False)", b:nim_project_root, cmd)
     let output = l:py_res
   else
     let output = system("nim " . cmd)

--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -13,7 +13,7 @@ if has('pythonx')
   exe 'pyxfile ' . fnameescape(s:plugin_path) . '/nim_vim.py'
 endif
 
-fun! nim#init()
+fun! nim#init() abort
   let cmd = printf('nim --dump.format:json --verbosity:0 dump %s', s:CurrentNimFile())
   let raw_dumpdata = system(cmd)
   if !v:shell_error && expand('%:e') == 'nim'
@@ -35,7 +35,7 @@ fun! nim#init()
   endif
 endf
 
-fun! s:UpdateNimLog()
+fun! s:UpdateNimLog() abort
   setlocal buftype=nofile
   setlocal bufhidden=hide
   setlocal noswapfile
@@ -66,7 +66,7 @@ command! NimTerminateService
 command! NimRestartService
   \ :exe printf("pyx nimRestartService('%s')", b:nim_project_root)
 
-fun! s:CurrentNimFile()
+fun! s:CurrentNimFile() abort
   let save_cur = getpos('.')
   call cursor(0, 0, 0)
   
@@ -104,7 +104,7 @@ let g:nim_symbol_types = {
   \ 'skEnumField': 'v',
   \ }
 
-fun! NimExec(op)
+fun! NimExec(op) abort
   let isDirty = getbufvar(bufnr('%'), '&modified')
   if isDirty
     let tmp = tempname() . bufname('%') . '_dirty.nim'
@@ -128,12 +128,12 @@ fun! NimExec(op)
   return output
 endf
 
-fun! NimExecAsync(op, Handler)
+fun! NimExecAsync(op, Handler) abort
   let result = NimExec(a:op)
   call a:Handler(result)
 endf
 
-fun! NimComplete(findstart, base)
+fun! NimComplete(findstart, base) abort
   if b:nim_caas_enabled == 0
     return -1
   endif
@@ -178,7 +178,7 @@ let g:neocomplete#sources#omni#input_patterns['nim'] = '[^. *\t]\.\w*'
 
 let g:nim_completion_callbacks = {}
 
-fun! NimAsyncCmdComplete(cmd, output)
+fun! NimAsyncCmdComplete(cmd, output) abort
   call add(g:nim_log, a:output)
   echom g:nim_completion_callbacks
   if has_key(g:nim_completion_callbacks, a:cmd)
@@ -191,7 +191,7 @@ fun! NimAsyncCmdComplete(cmd, output)
   return 1
 endf
 
-fun! GotoDefinition_nim_ready(def_output)
+fun! GotoDefinition_nim_ready(def_output) abort
   if v:shell_error
     echo 'nim was unable to locate the definition. exit code: ' . v:shell_error
     " echoerr a:def_output
@@ -211,23 +211,23 @@ fun! GotoDefinition_nim_ready(def_output)
   return 1
 endf
 
-fun! GotoDefinition_nim()
+fun! GotoDefinition_nim() abort
   call NimExecAsync('--def', function('GotoDefinition_nim_ready'))
 endf
 
-fun! FindReferences_nim()
+fun! FindReferences_nim() abort
   setloclist()
 endf
 
 " Syntastic syntax checking
-fun! SyntaxCheckers_nim_nim_GetLocList()
+fun! SyntaxCheckers_nim_nim_GetLocList() abort
   let makeprg = 'nim check --hints:off --listfullpaths ' . s:CurrentNimFile()
   let errorformat = &errorformat
   
   return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat })
 endf
 
-function! SyntaxCheckers_nim_nim_IsAvailable()
+function! SyntaxCheckers_nim_nim_IsAvailable() abort
   return executable('nim')
 endfunction
 

--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -119,7 +119,7 @@ fun! NimExec(op) abort
 
   if b:nim_caas_enabled
     exe printf("pyx nimExecCmd('%s', '%s', False)", b:nim_project_root, cmd)
-    let output = l:py_res
+    let output = get(l:, 'py_res', '')
   else
     let output = system('nim ' . cmd)
   endif

--- a/compiler/nim.vim
+++ b/compiler/nim.vim
@@ -1,10 +1,10 @@
-if exists("current_compiler")
+if exists('current_compiler')
   finish
 endif
 
-let current_compiler = "nim"
+let current_compiler = 'nim'
 
-if exists(":CompilerSet") != 2 " older Vim always used :setlocal
+if exists(':CompilerSet') != 2 " older Vim always used :setlocal
   command -nargs=* CompilerSet setlocal <args>
 endif
 

--- a/ftdetect/nim.vim
+++ b/ftdetect/nim.vim
@@ -1,2 +1,4 @@
-au BufNewFile,BufRead *.nim,*.nims,*.nimble set filetype=nim
+augroup nim_vim
+  au BufNewFile,BufRead *.nim,*.nims,*.nimble set filetype=nim
+augroup END
 

--- a/ftplugin/nim.vim
+++ b/ftplugin/nim.vim
@@ -1,4 +1,4 @@
-if exists("b:nim_loaded")
+if exists('b:nim_loaded')
   finish
 endif
 

--- a/indent/nim.vim
+++ b/indent/nim.vim
@@ -38,7 +38,7 @@ function! GetNimIndent(lnum)
   endif
 
   " If the start of the line is in a string don't change the indent.
-  if has('syntax_items') && synIDattr(synID(a:lnum, 1, 1), 'name') =~ 'String$'
+  if has('syntax_items') && synIDattr(synID(a:lnum, 1, 1), 'name') =~# 'String$'
     return -1
   endif
 
@@ -54,12 +54,12 @@ function! GetNimIndent(lnum)
     " If the last character in the line is a comment, do a binary search for
     " the start of the comment.  synID() is slow, a linear search would take
     " too long on a long line.
-    if synIDattr(synID(plnum, pline_len, 1), 'name') =~ 'Comment$'
+    if synIDattr(synID(plnum, pline_len, 1), 'name') =~# 'Comment$'
       let min = 1
       let max = pline_len
       while min < max
         let col = (min + max) / 2
-        if synIDattr(synID(plnum, col, 1), 'name') =~ 'Comment$'
+        if synIDattr(synID(plnum, col, 1), 'name') =~# 'Comment$'
           let max = col
         else
           let min = col + 1
@@ -78,16 +78,16 @@ function! GetNimIndent(lnum)
     endwhile
   endif
 
-  if cline =~ '^\s*\(if\|when\|for\|while\|case\|of\|try\)\>'
+  if cline =~# '^\s*\(if\|when\|for\|while\|case\|of\|try\)\>'
     " This is a benign line, do nothing
     return -1
   endif
 
   " If the current line begins with a keyword that lines up with "try"
-  if cline =~ '^\s*\(except\|finally\)\>'
+  if cline =~# '^\s*\(except\|finally\)\>'
     let lnum = a:lnum - 1
     while lnum >= 1
-      if getline(lnum) =~ '^\s*\(try\|except\)\>'
+      if getline(lnum) =~# '^\s*\(try\|except\)\>'
         let ind = indent(lnum)
         if ind >= clindent
           return -1     " indent is already less than this
@@ -100,31 +100,31 @@ function! GetNimIndent(lnum)
   endif
 
   " If the current line begins with a header keyword, dedent
-  if cline =~ '^\s*\(elif\|else\)\>'
+  if cline =~# '^\s*\(elif\|else\)\>'
     return s:FindStartLine(a:lnum, '^\s*\(if\|when\|elif\|of\)')
   endif
 
-  if pline =~ ':\s*$'
+  if pline =~# ':\s*$'
     "return s:FindStartLine(plnum, '(^\s*\(if\|when\|else\|elif\|case\|of\|try\|except\|finally\)\>)\|\<do\>') + &sw
     return s:FindStartLine(plnum, '^\s*\(if\|when\|else\|elif\|for\|while\|case\|of\|try\|except\|finally\)\>') + &sw
   endif
 
-  if pline =~ '=\s*$'
+  if pline =~# '=\s*$'
     return s:FindStartLine(plnum, '^\s*\(proc\|template\|macro\|iterator\)\>') + &sw
   endif
 
   " if we got here, this should be the begging of a multi-line if expression for example
-  if pline =~ '^\s*\(if\|when\|proc\|iterator\|macro\|template\|for\|while\)[^:]*$'
+  if pline =~# '^\s*\(if\|when\|proc\|iterator\|macro\|template\|for\|while\)[^:]*$'
     return plindent + &sw
   endif
 
-  if pline =~ '\(type\|import\|const\|var\|let\)\s*$'
-    \ || pline =~ '=\s*\(object\|enum\|tuple\|concept\)'
+  if pline =~# '\(type\|import\|const\|var\|let\)\s*$'
+    \ || pline =~# '=\s*\(object\|enum\|tuple\|concept\)'
     return plindent + &sw
   endif
 
   " If the previous line was a stop-execution statement...
-  if pline =~ '^\s*\(break\|continue\|raise\|return\)\>'
+  if pline =~# '^\s*\(break\|continue\|raise\|return\)\>'
     " See if the user has already dedented
     if indent(a:lnum) > plindent - &sw
       " If not, recommend one dedent

--- a/indent/nim.vim
+++ b/indent/nim.vim
@@ -1,5 +1,5 @@
 " Only load this indent file when no other was loaded.
-if exists("b:did_indent")
+if exists('b:did_indent')
   finish
 endif
 let b:did_indent = 1
@@ -12,7 +12,7 @@ setlocal indentexpr=GetNimIndent(v:lnum)
 setlocal indentkeys=!^F,o,O,<:>,0),0],0},=elif
 
 " Only define the function once.
-if exists("*GetNimIndent")
+if exists('*GetNimIndent')
   finish
 endif
 
@@ -38,7 +38,7 @@ function! GetNimIndent(lnum)
   endif
 
   " If the start of the line is in a string don't change the indent.
-  if has('syntax_items') && synIDattr(synID(a:lnum, 1, 1), "name") =~ "String$"
+  if has('syntax_items') && synIDattr(synID(a:lnum, 1, 1), 'name') =~ 'String$'
     return -1
   endif
 
@@ -54,12 +54,12 @@ function! GetNimIndent(lnum)
     " If the last character in the line is a comment, do a binary search for
     " the start of the comment.  synID() is slow, a linear search would take
     " too long on a long line.
-    if synIDattr(synID(plnum, pline_len, 1), "name") =~ "Comment$"
+    if synIDattr(synID(plnum, pline_len, 1), 'name') =~ 'Comment$'
       let min = 1
       let max = pline_len
       while min < max
         let col = (min + max) / 2
-        if synIDattr(synID(plnum, col, 1), "name") =~ "Comment$"
+        if synIDattr(synID(plnum, col, 1), 'name') =~ 'Comment$'
           let max = col
         else
           let min = col + 1

--- a/syntax/nim.vim
+++ b/syntax/nim.vim
@@ -156,7 +156,7 @@ syn sync match nimSync grouphere NONE "):$"
 syn sync maxlines=200
 syn sync minlines=2000
 
-if v:version >= 508 || !exists("did_nim_syn_inits")
+if v:version >= 508 || !exists('did_nim_syn_inits')
   if v:version <= 508
     let did_nim_syn_inits = 1
     command -nargs=+ HiLink hi link <args>
@@ -200,5 +200,5 @@ if v:version >= 508 || !exists("did_nim_syn_inits")
   delcommand HiLink
 endif
 
-let b:current_syntax = "nim"
+let b:current_syntax = 'nim'
 

--- a/syntax/nim.vim
+++ b/syntax/nim.vim
@@ -2,28 +2,28 @@
 " For version 6.x: Quit when a syntax file was already loaded
 if version < 600
   syntax clear
-elseif exists("b:current_syntax")
+elseif exists('b:current_syntax')
   finish
 endif
 
 " Keep user-supplied options
-if !exists("nim_highlight_numbers")
+if !exists('nim_highlight_numbers')
   let nim_highlight_numbers = 1
 endif
-if !exists("nim_highlight_builtins")
+if !exists('nim_highlight_builtins')
   let nim_highlight_builtins = 1
 endif
-if !exists("nim_highlight_exceptions")
+if !exists('nim_highlight_exceptions')
   let nim_highlight_exceptions = 1
 endif
-if !exists("nim_highlight_space_errors")
+if !exists('nim_highlight_space_errors')
   let nim_highlight_space_errors = 1
 endif
-if !exists("nim_highlight_special_vars")
+if !exists('nim_highlight_special_vars')
   let nim_highlight_special_vars = 1
 endif
 
-if exists("nim_highlight_all")
+if exists('nim_highlight_all')
   let nim_highlight_numbers      = 1
   let nim_highlight_builtins     = 1
   let nim_highlight_exceptions   = 1

--- a/syntax/nim.vim
+++ b/syntax/nim.vim
@@ -1,6 +1,6 @@
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
-if version < 600
+if v:version < 600
   syntax clear
 elseif exists('b:current_syntax')
   finish

--- a/syntax/nim.vim
+++ b/syntax/nim.vim
@@ -156,8 +156,8 @@ syn sync match nimSync grouphere NONE "):$"
 syn sync maxlines=200
 syn sync minlines=2000
 
-if version >= 508 || !exists("did_nim_syn_inits")
-  if version <= 508
+if v:version >= 508 || !exists("did_nim_syn_inits")
+  if v:version <= 508
     let did_nim_syn_inits = 1
     command -nargs=+ HiLink hi link <args>
   else


### PR DESCRIPTION
* Use has("pythonx") and `pyx`, `pyxfile`
* Fixes syntax or usages checked via vint command.

I don't enable python2 on Vim. So always get an error when leaving Vim.